### PR TITLE
Add Drupal 11 compatibility

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,15 +35,25 @@ job-build: &job-build
         when: always
 
 jobs:
-  build-php-8.3:
+  build-php-8.3-d10:
     <<: *container_config
     <<: *job-build
+    environment:
+      DRUPAL_CORE_VERSION: "^10"
+
+  build-php-8.3-d11:
+    <<: *container_config
+    <<: *job-build
+    environment:
+      DRUPAL_CORE_VERSION: "^11"
 
   build-php-8.2:
     <<: *container_config
     docker:
       - image: cimg/php:8.2-browsers
     <<: *job-build
+    environment:
+      DRUPAL_CORE_VERSION: "^10"
 
   deploy:
     <<: *container_config
@@ -60,17 +70,22 @@ workflows:
   version: 2
   main:
     jobs:
-      - build-php-8.3:
+      - build-php-8.3-d10:
+          filters:
+            tags:
+              only: /.*/
+      - build-php-8.3-d11:
           filters:
             tags:
               only: /.*/
       - build-php-8.2:
           filters:
             tags:
-              only: /.*/
+              only: /.*/ 
       # - deploy:
       #     requires:
-      #       - build-php-8.3
+      #       - build-php-8.3-d10
+      #       - build-php-8.3-d11
       #       - build-php-8.2
       #     filters:
       #       tags:

--- a/alert_banner.info.yml
+++ b/alert_banner.info.yml
@@ -3,7 +3,7 @@ type: module
 description: 'Provides an alert banner block that can be placed anywhere on the site.'
 package: Custom
 version: '10.x-1.2'
-core_version_requirement: ^10
+core_version_requirement: ^10 || ^11
 php: 8.3
 dependencies:
   - drupal:block

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,6 @@
     "version": "10.x-1.2",
     "require": {
         "php": ">=8.3",
-        "drupal/core": "^10"
+        "drupal/core": "^10 || ^11"
     }
 }


### PR DESCRIPTION
## Summary
- Updated module to support both Drupal 10 and Drupal 11
- Added CI testing for both D10 and D11 environments
- No code changes required as module already meets D11 standards

## Changes
- Updated `core_version_requirement` in alert_banner.info.yml to `^10 || ^11`
- Updated drupal/core requirement in composer.json to `^10 || ^11`
- Added separate CI jobs for PHP 8.3 with D10 and D11
- Updated CI workflow to test against both major versions

## Testing
- No deprecated APIs found in codebase
- Module is compatible with:
  - PHP 8.3+ (already required)
  - jQuery 4 (no deprecated methods used)
  - Symfony 7 (no direct usage)
  - PHPUnit 10 (for future test additions)

## Compatibility
This update maintains full backward compatibility with Drupal 10 while adding support for Drupal 11.

Closes #7