### PR TITLE
Update module version to 1.3

### DIFF
--- a/alert_banner.info.yml
+++ b/alert_banner.info.yml
@@ -2,7 +2,7 @@ name: Alert Banner
 type: module
 description: 'Provides an alert banner block that can be placed anywhere on the site.'
 package: Custom
-version: '10.x-1.2'
+version: '1.3'
 core_version_requirement: ^10 || ^11
 php: 8.3
 dependencies:

--- a/alert_banner.libraries.yml
+++ b/alert_banner.libraries.yml
@@ -1,5 +1,5 @@
 alert_banner:
-  version: '10.x-1.2'
+  version: '10.x-1.3'
   css:
     theme:
       css/alert_banner.css: { minified: true }
@@ -11,7 +11,7 @@ alert_banner:
     - core/drupalSettings
 
 alert_banner_au_dta:
-  version: '10.x-1.2'
+  version: '10.x-1.3'
   css:
     theme:
       css/alert_banner_au_dta.css: { minified: true }

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "type": "drupal-module",
     "license": "GPL-2.0-or-later",
     "homepage": "https://www.salsadigital.com.au",
-    "version": "10.x-1.2",
+    "version": "1.3.0",
     "require": {
         "php": ">=8.3",
         "drupal/core": "^10 || ^11"


### PR DESCRIPTION
## Summary
Updates the module version to 1.3 following the addition of Drupal 11 compatibility.

## Changes
- **alert_banner.info.yml**: Version updated to `1.3`
- **composer.json**: Version updated to `1.3.0` (semantic versioning)
- **alert_banner.libraries.yml**: Library versions updated to `10.x-1.3`

## Version Format Rationale
- **info.yml**: Uses `1.3` for Drupal module version display
- **composer.json**: Uses `1.3.0` for proper semantic versioning in Composer
- **libraries.yml**: Uses `10.x-1.3` following Drupal library version conventions

This version bump reflects the new feature of Drupal 11 compatibility added in PR #7.